### PR TITLE
feat: Allow run function to return result to onComplete handler

### DIFF
--- a/src/options.ts
+++ b/src/options.ts
@@ -17,9 +17,9 @@ export interface EnqueueOptions {
   delayMs?: number;
 }
 
-export interface RunnerFuncs<T> {
-  run: (job: DequeuedJob<T>) => Promise<void>;
-  onComplete?: (job: DequeuedJob<T>) => Promise<void>;
+export interface RunnerFuncs<T, R = void> {
+  run: (job: DequeuedJob<T>) => Promise<R>;
+  onComplete?: (job: DequeuedJob<T>, result: R) => Promise<void>;
   onError?: (job: DequeuedJobError<T>) => Promise<void>;
 }
 


### PR DESCRIPTION
The run function can now return a result value that gets passed to the onComplete callback, enabling better job result handling and state management. The Runner class now accepts an optional second type parameter R for the result type (defaults to void for backward compatibility).